### PR TITLE
Include `MaskedInputProps` in `CurrencyInput` prop types

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import classnames from 'classnames';
-import MaskedInput from 'react-text-mask';
+import MaskedInput, { MaskedInputProps } from 'react-text-mask';
 import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 import InputGroup from './InputGroup';
 import InputGroupAddon from './InputGroupAddon';
@@ -34,11 +34,11 @@ type Props = {
   className?: string;
   id?: string;
   includeThousandsSeparator?: boolean;
-  inputProps?: { className?: string };
+  inputProps?: MaskedInputProps;
   size?: string;
   state?: any;
   type?: any;
-};
+} & MaskedInputProps;
 
 const defaultProps = {
   allowDecimal: true,


### PR DESCRIPTION
The way that the underlying `MaskedInput` is passed props allows any of its props to be specified in either `inputProps` or `props`:
https://github.com/mycase/react-gears/blob/1adbf65196bce045bc1596a602db6a4e3998a849/src/components/CurrencyInput.tsx#L63-L83

This means that props like `value`, `onChange`, or `onBlur` can be passed in either `inputProps` or in `props`, and they will make their way to the underlying `MaskedInput`. Since this is allowed, we need our type definition to permit passing these props, so we're including `MaskedInputProps`, which extends `React.InputHTMLAttributes<HTMLInputElement>`:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/1e483f105078276b618a943bde66a3d8d6bb26b3/types/react-text-mask/index.d.ts#L13-L14

Note: Prior to https://github.com/appfolio/react-gears/pull/730, `CurrencyInputProps` extended `React.InputHTMLAttributes<HTMLInputElement>`:
https://github.com/mycase/react-gears/blob/039ca6a4f058e91cd0e3dd2a40d170224c879120/src/components/CurrencyInput.d.ts#L4
which allowed props like `value`, `onChange`, or `onBlur` to be passed in the `props` (but not in `inputProps`).