### PR TITLE
Declare `onToggle` prop as optional in the `ExpandableSection` component

### DIFF
--- a/src/components/ExpandableSection.tsx
+++ b/src/components/ExpandableSection.tsx
@@ -6,7 +6,7 @@ import Icon from './Icon';
 interface ExpandableSectionProps {
   children?: React.ReactNode;
   className?: string;
-  onToggle: (open: boolean) => void;
+  onToggle?: (open: boolean) => void;
   open?: boolean;
   title: string;
 }
@@ -14,7 +14,7 @@ interface ExpandableSectionProps {
 const ExpandableSection: FunctionComponent<ExpandableSectionProps> = ({
   children,
   className,
-  onToggle,
+  onToggle = () => {},
   open: defaultOpen,
   title
 }) => {


### PR DESCRIPTION
`ExpandableSection.defaultProps` declares a default `onToggle` prop:
https://github.com/mycase/react-gears/blob/1adbf65196bce045bc1596a602db6a4e3998a849/src/components/ExpandableSection.tsx#L54-L57
and there are several tests in `ExpandableSection.spec.js` that do not pass the `onToggle` prop:
https://github.com/mycase/react-gears/blob/1adbf65196bce045bc1596a602db6a4e3998a849/test/components/ExpandableSection.spec.js#L7-L61
Despite this, the `ExpandableSectionProps` interface actually defined it as a required prop. This PR changes `onToggle` back to an optional prop (consistent with the `defaultProps` declaration) like it was prior to https://github.com/appfolio/react-gears/pull/713.