### PR TITLE
Declare `summary` prop as optional in the `Paginator` component

### DIFF
--- a/src/components/Paginator.tsx
+++ b/src/components/Paginator.tsx
@@ -56,7 +56,7 @@ type PaginatorProps = {
   onClick: (page: number) => void,
   perPage?: number,
   size?: 'sm' | 'lg',
-  summary: React.ReactNode,
+  summary?: React.ReactNode,
   totalItems: number,
 }
 


### PR DESCRIPTION
The `Paginator` component has built-in handling for the absence of the `summary` prop:
https://github.com/mycase/react-gears/blob/1adbf65196bce045bc1596a602db6a4e3998a849/src/components/Paginator.tsx#L119
and there are numerous tests in `Paginator.spec.js` that do not pass the `summary` prop:
https://github.com/mycase/react-gears/blob/1adbf65196bce045bc1596a602db6a4e3998a849/test/components/Paginator.spec.js#L8-L189
Despite this, the `PaginatorProps` type added in https://github.com/appfolio/react-gears/pull/740 actually defined `summary` as a required prop. This PR updates the type definition to correctly declare it as optional.