### PR TITLE
Restore behavior of forwarding `Select`'s `name` prop to `SelectElement`

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -74,6 +74,7 @@ class Select extends React.Component {
         valueComponent={valueComponentRenderer}
         ref={this.bindInput}
         className={classNames}
+        name={name}
         {...props}
       />
     );

--- a/test/components/Select.spec.js
+++ b/test/components/Select.spec.js
@@ -135,6 +135,15 @@ describe('<Select />', () => {
     assert(component.find('input[name="Yowza"]').exists());
   });
 
+  it('should use name prop for underlying hidden input', () => {
+    const component = mount(<Select name="Yowza" options={OPTIONS} />);
+    assert(component.find('input[name="Yowza"]').exists());
+    assert(!component.find('input[name="Yowza"][type="hidden"]').exists());
+    component.instance().onChange(OPTIONS[3]);
+    component.update();
+    assert(component.find('input[name="Yowza"][type="hidden"]').exists());
+  });
+
   it('should pass inputProps name prop', () => {
     const component = mount(<Select inputProps={{ name: 'Gonzo' }} />);
     assert(component.find('input[name="Gonzo"]').exists());


### PR DESCRIPTION
Prior to https://github.com/appfolio/react-gears/pull/671, the `name` prop of the `Select` component would be passed to `<SelectElement>` via the `{...props}` spread. But after that commit, `name` is no longer part of the `props` rest parameters, so it was no longer being passed to `SelectElement`. To fix this, we explicitly pass `name={name}`. This is important because without the `name` prop, the component won't render its underlying hidden input field, as a result of this code:
https://github.com/HubSpot/react-select-plus/blob/v1.2.0/src/Select.js#L1148-L1149
```js
	renderHiddenField (valueArray) {
		if (!this.props.name) return;
```