### PR TITLE
Allow consumers to import from `src` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "files": [
     "dist",
     "lib",
-    "es"
+    "es",
+    "src"
   ],
   "types": "lib/index.d.ts",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "dist",
     "lib",
     "es",
-    "src"
+    "src",
+    ".babelrc"
   ],
   "types": "lib/index.d.ts",
   "publishConfig": {


### PR DESCRIPTION
This gives consumers the option of importing directly from the plain `src` code, which can result in more optimal application bundles because things like babel helpers/runtime code can be shared rather than duplicated in both the (pre-transpiled) `react-gears` library code and the application code.